### PR TITLE
Add dependency for FGtatsuro.python-requirements.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ install:
   - ansible --version
 
   # Resolve dependencies(When target role isn't installed via Ansible Galaxy, auto resolution of dependencies doesn't occur.
-  - ansible-galaxy install futurice.pip
+  - ansible-galaxy install FGtatsuro.python-requirements futurice.pip
 
 before_script:
   - docker run -it -d --name container python:2 /bin/bash

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -13,4 +13,5 @@ galaxy_info:
     - development
 
 dependencies: 
+  - FGtatsuro.python-requirements
   - futurice.pip

--- a/spec/ansible_spec.rb
+++ b/spec/ansible_spec.rb
@@ -1,13 +1,5 @@
 require "spec_helper_#{ENV['SPEC_TARGET_BACKEND']}"
 
-describe package('python-dev'), :if => os[:family] == 'debian' do
-  it { should be_installed }
-end
-
-describe package('build-essential'), :if => os[:family] == 'debian' do
-  it { should be_installed }
-end
-
 describe package('ansible') do
   it { should be_installed.by('pip') }
 end


### PR DESCRIPTION
Some specs are removed because they are already checked in FGtatsuro.python-requirements.
